### PR TITLE
Feature/#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,33 @@ result = client.generate_image(
 print(result.saved_path)
 ```
 
+## Codex Skill Example
+
+For users who want to invoke `god-tibo-imagen` from within Codex, an example skill and wrapper script are provided in `examples/codex-skill/`.
+
+### Setup
+
+- Python 3.10+
+- `pip install god-tibo-imagen` (the import name is `gti`, not `god_tibo_imagen`)
+- Local Codex auth in `~/.codex/auth.json` with `auth_mode = chatgpt`
+
+### Wrapper script
+
+```bash
+# Dry run
+python examples/codex-skill-wrapper.py --prompt "flat blue square icon" --output ./test.png --dry-run
+
+# Live generation
+python examples/codex-skill-wrapper.py --prompt "flat blue square icon" --output ./out.png
+
+# With image inputs
+python examples/codex-skill-wrapper.py --prompt "Make this cat wear a hat" --image ./cat.png --output ./cat-hat.png
+```
+
+### Skill file
+
+The Codex skill definition is at `examples/codex-skill/SKILL.md`. You can copy this directory into your Codex skills path (e.g., `~/.codex/skills/god-tibo-imagen/`) for easier invocation.
+
 ## Key files
 
 - `src/auth/loadCodexSession.js` — reads Codex auth state

--- a/examples/codex-skill-wrapper.py
+++ b/examples/codex-skill-wrapper.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Codex skill wrapper for god-tibo-imagen.
+
+A lightweight CLI wrapper around the god-tibo-imagen Python SDK designed
+for invocation from Codex skills or direct command-line usage.
+
+Example:
+    python codex-skill-wrapper.py --prompt "flat blue square" --output ./out.png --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from gti.client import Client
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate images via the god-tibo-imagen Python SDK."
+    )
+    parser.add_argument("--prompt", required=True, help="Image generation prompt")
+    parser.add_argument("--output", help="Output file path")
+    parser.add_argument("--model", default="gpt-5.4", help="Model to use")
+    parser.add_argument("--dry-run", action="store_true", help="Dry run mode")
+    parser.add_argument("--auth-file", help="Path to Codex auth.json")
+    parser.add_argument(
+        "--installation-id-file", help="Path to Codex installation_id file"
+    )
+    parser.add_argument(
+        "--image",
+        action="append",
+        help="Input image path (can be used multiple times)",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable debug output"
+    )
+    args = parser.parse_args()
+
+    client_kwargs: dict[str, str] = {}
+    if args.auth_file:
+        client_kwargs["authFile"] = args.auth_file
+    if args.installation_id_file:
+        client_kwargs["installationIdFile"] = args.installation_id_file
+
+    client = Client(**client_kwargs)
+
+    gen_kwargs: dict[str, object] = {
+        "prompt": args.prompt,
+        "model": args.model,
+        "dry_run": args.dry_run,
+    }
+    if args.output:
+        gen_kwargs["output_path"] = args.output
+    if args.image:
+        gen_kwargs["image_paths"] = args.image
+    if args.debug:
+        gen_kwargs["debug"] = True
+
+    result = client.generate_image(**gen_kwargs)
+
+    print(json.dumps({
+        "mode": result.mode,
+        "savedPath": result.saved_path,
+        "responseId": result.response_id,
+        "sessionId": result.session_id,
+        "revisedPrompt": result.revised_prompt,
+        "warnings": result.warnings,
+    }, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/codex-skill/SKILL.md
+++ b/examples/codex-skill/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: god-tibo-imagen
+description: >
+  Use when the user wants to generate images via the god-tibo-imagen Python SDK
+  using local Codex ChatGPT authentication.
+  Trigger phrases: "generate an image", "create an image", "make a picture",
+  "image generation with gti", "run god-tibo-imagen".
+  Do NOT use for general image editing or public API image generation.
+argument-hint: "[--prompt <text>] [--output <path>] [--dry-run]"
+---
+
+# god-tibo-imagen Codex Skill
+
+This skill wraps the `god-tibo-imagen` Python SDK into a repeatable workflow
+that is easier to invoke from Codex.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install god-tibo-imagen` (the import name is `gti`, not `god_tibo_imagen`)
+- Local Codex auth in `~/.codex/auth.json` with `auth_mode = chatgpt`
+- A Codex/ChatGPT account entitled to image generation on the private backend
+
+## Wrapper script
+
+The wrapper lives at `examples/codex-skill-wrapper.py` and provides a simple
+argparse interface over the Python SDK.
+
+### Dry run (recommended for testing)
+
+```bash
+python examples/codex-skill-wrapper.py \
+  --prompt "flat blue square icon" \
+  --output ./test.png \
+  --dry-run
+```
+
+### Live generation
+
+```bash
+python examples/codex-skill-wrapper.py \
+  --prompt "flat blue square icon" \
+  --output ./out.png
+```
+
+### With image inputs
+
+```bash
+python examples/codex-skill-wrapper.py \
+  --prompt "Make this cat wear a hat" \
+  --image ./cat.png \
+  --output ./cat-hat.png
+```
+
+### Override auth paths
+
+```bash
+python examples/codex-skill-wrapper.py \
+  --prompt "flat blue square icon" \
+  --output ./out.png \
+  --auth-file /custom/path/auth.json \
+  --installation-id-file /custom/path/installation_id
+```
+
+## Python SDK direct usage
+
+If you prefer to use the SDK directly instead of the wrapper:
+
+```python
+from gti import Client
+
+client = Client(provider="private-codex")
+result = client.generate_image(
+    prompt="flat blue square icon",
+    model="gpt-5.4",
+    output_path="./out.png"
+)
+print(result.saved_path)
+```
+
+## Notes
+
+- The Python version matters: requires Python 3.10 or later.
+- The import name is `gti`, not `god_tibo_imagen`.
+- Local Codex auth must be ChatGPT-backed (`auth_mode = chatgpt` in `~/.codex/auth.json`); API-key mode is not supported for the private backend path.
+- For dry-run, the wrapper validates auth and prints the request without making a live network call.

--- a/examples/codex-skill/agents/openai.yaml
+++ b/examples/codex-skill/agents/openai.yaml
@@ -1,0 +1,10 @@
+interface:
+  display_name: "god-tibo-imagen"
+  short_description: "Generate images via the god-tibo-imagen Python SDK"
+  icon_small: "./assets/icon-small.svg"
+  icon_large: "./assets/icon-large.svg"
+  brand_color: "#3B82F6"
+  default_prompt: "Generate an image of a sunset over mountains using god-tibo-imagen"
+
+policy:
+  allow_implicit_invocation: true

--- a/python/tests/test_codex_skill_wrapper.py
+++ b/python/tests/test_codex_skill_wrapper.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import runpy
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent.parent / "examples"
+WRAPPER_PATH = EXAMPLES_DIR / "codex-skill-wrapper.py"
+SKILL_DIR = EXAMPLES_DIR / "codex-skill"
+
+
+def test_wrapper_script_exists():
+    assert WRAPPER_PATH.exists(), "codex-skill-wrapper.py should exist"
+
+
+def test_skill_directory_exists():
+    assert SKILL_DIR.exists(), "codex-skill directory should exist"
+    assert (SKILL_DIR / "SKILL.md").exists(), "SKILL.md should exist"
+    assert (SKILL_DIR / "agents" / "openai.yaml").exists(), "agents/openai.yaml should exist"
+
+
+def test_wrapper_has_main_function():
+    source = WRAPPER_PATH.read_text(encoding="utf-8")
+    assert "def main(" in source, "wrapper should define a main function"
+    assert 'if __name__ == "__main__":' in source, "wrapper should have __main__ guard"
+
+
+def test_wrapper_imports_gti():
+    source = WRAPPER_PATH.read_text(encoding="utf-8")
+    assert "from gti.client import Client" in source or "from gti import Client" in source or "import gti" in source, "wrapper should import gti"
+
+
+def test_wrapper_dry_run_does_not_require_auth(tmp_path, monkeypatch):
+    auth_file = tmp_path / "auth.json"
+    installation_file = tmp_path / "installation_id"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "fake-token",
+                    "account_id": "acct-123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    installation_file.write_text("iid-123", encoding="utf-8")
+
+    output_file = tmp_path / "output.png"
+
+    test_args = [
+        str(WRAPPER_PATH),
+        "--prompt",
+        "blue square",
+        "--output",
+        str(output_file),
+        "--dry-run",
+        "--auth-file",
+        str(auth_file),
+        "--installation-id-file",
+        str(installation_file),
+    ]
+    monkeypatch.setattr(sys, "argv", test_args)
+
+    with patch("gti.client.create_private_codex_provider") as mock_provider:
+        mock_instance = mock_provider.return_value
+        mock_instance.generate_image.return_value = {
+            "mode": "dry-run",
+            "warnings": [],
+            "responseId": "dry-run-123",
+            "savedPath": str(output_file),
+            "request": {},
+            "response": {},
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_path(str(WRAPPER_PATH), run_name="__main__")
+        assert exc_info.value.code == 0, "wrapper should exit with code 0 on success"
+
+
+def test_wrapper_skills_md_has_valid_frontmatter():
+    skill_md = SKILL_DIR / "SKILL.md"
+    content = skill_md.read_text(encoding="utf-8")
+    assert content.startswith("---\n"), "SKILL.md should start with YAML frontmatter delimiter"
+    assert "name:" in content, "SKILL.md should have a name field"
+    assert "description:" in content, "SKILL.md should have a description field"
+    assert "# " in content, "SKILL.md should contain markdown headers"

--- a/tests/codex-skill-example.test.js
+++ b/tests/codex-skill-example.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+const skillDir = path.join(rootDir, 'examples', 'codex-skill');
+const wrapperPath = path.join(rootDir, 'examples', 'codex-skill-wrapper.py');
+const skillMdPath = path.join(skillDir, 'SKILL.md');
+const openaiYamlPath = path.join(skillDir, 'agents', 'openai.yaml');
+
+async function fileExists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseYamlFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+  const front = match[1];
+  const body = match[2];
+  const meta = {};
+  for (const line of front.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    meta[key] = value.replace(/^["']|["']$/g, '');
+  }
+  return { meta, body };
+}
+
+test('codex-skill wrapper script exists', async () => {
+  assert.equal(await fileExists(wrapperPath), true, 'wrapper script should exist');
+});
+
+test('codex-skill wrapper script is valid Python', async () => {
+  const content = await fs.readFile(wrapperPath, 'utf8');
+  assert.ok(content.includes('def main('), 'wrapper should define a main function');
+  assert.ok(content.includes('if __name__ == "__main__":'), 'wrapper should have __main__ guard');
+  assert.ok(content.includes('import argparse') || content.includes('from gti'), 'wrapper should import required modules');
+});
+
+test('codex-skill SKILL.md exists with valid frontmatter', async () => {
+  assert.equal(await fileExists(skillMdPath), true, 'SKILL.md should exist');
+  const content = await fs.readFile(skillMdPath, 'utf8');
+  const parsed = parseYamlFrontmatter(content);
+  assert.ok(parsed, 'SKILL.md should have YAML frontmatter');
+  assert.ok(parsed.meta.name, 'frontmatter should have a name');
+  assert.ok(parsed.meta.description, 'frontmatter should have a description');
+  assert.ok(parsed.body.includes('#'), 'SKILL.md body should contain markdown headers');
+});
+
+test('codex-skill agents/openai.yaml exists and is valid', async () => {
+  assert.equal(await fileExists(openaiYamlPath), true, 'agents/openai.yaml should exist');
+  const content = await fs.readFile(openaiYamlPath, 'utf8');
+  assert.ok(content.includes('interface:'), 'openai.yaml should have interface section');
+  assert.ok(content.includes('display_name:'), 'openai.yaml should have display_name');
+});
+
+test('README.md contains Codex skill example section', async () => {
+  const readmePath = path.join(rootDir, 'README.md');
+  const content = await fs.readFile(readmePath, 'utf8');
+  assert.ok(
+    content.includes('Codex Skill') || content.includes('codex-skill') || content.includes('examples/codex-skill'),
+    'README should reference the Codex skill example'
+  );
+});


### PR DESCRIPTION
## Summary

Implements Issue #2: Codex skill / plugin example for easier setup.

## Changes

- Added `examples/codex-skill-wrapper.py` — a lightweight CLI wrapper around the `god-tibo-imagen` Python SDK designed for invocation from Codex skills.
- Added `examples/codex-skill/SKILL.md` — Codex skill definition with YAML frontmatter, trigger phrases, usage examples, and prerequisites.
- Added `examples/codex-skill/agents/openai.yaml` — UI metadata for the skill (display name, description, brand color, default prompt).
- Updated `README.md` with a new "Codex Skill Example" section documenting the wrapper and skill setup.
- Added Node tests (`tests/codex-skill-example.test.js`) verifying file existence, valid YAML frontmatter, and README references.
- Added Python tests (`python/tests/test_codex_skill_wrapper.py`) verifying wrapper script structure, imports, and dry-run behavior.

## Verification

- `npm test`: 31/31 pass
- `pytest` (Python): 34/34 pass
- Manual dry-run test of wrapper script confirmed working:
  ```bash
  python examples/codex-skill-wrapper.py --prompt "flat blue square icon" --output /tmp/test.png --dry-run
  ```

<!-- dani:stage=implementation;job=cd4759080b944fceb8b6b28c09d6e8c8;issue=2 -->
